### PR TITLE
Fix permissions when provisioning.

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,7 +133,11 @@ func (vault *VaultBroker) Provision(instanceID string, details brokerapi.Provisi
 			Rules: fmt.Sprintf(`
 path "secret/%s" {
   capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-}`, instanceID),
+}
+
+path "secret/%s/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}`, instanceID, instanceID),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
The intended behavior is to allow read/write/sudo access to
`secret/<GUID>` and _everything below_.

Add a separate rule for the _everything below_ case.

Before:
```
$ vault capabilities secret/<GUID>
Capabilities: [sudo read list update delete create]

$ vault capabilities secret/<GUID>/foo
Capabilities: [deny]
```

After:
```
$ vault capabilities secret/<GUID>
Capabilities: [sudo read list update delete create]

$ vault capabilities secret/<GUID>/foo
Capabilities: [sudo read list update delete create]
```