### PR TITLE
Fix service unbind

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func (vault *VaultBroker) Unbind(instanceID, bindingID string, details brokerapi
 	}
 
 	log.Printf("[unbind %s / %s] revoking token '%s'", instanceID, bindingID, secret["token"])
-	res, err = vault.Do("PUT",
+	res, err = vault.Do("POST",
 		fmt.Sprintf("/v1/auth/token/revoke/%s", secret["token"]), nil)
 	if err != nil {
 		log.Printf("[unbind %s / %s] error: %s", instanceID, bindingID, err)


### PR DESCRIPTION
When attempting to unbind an app from the vault service,
you receive the following error:

```
FAILED
Service instance vault: Service broker error: Received 200 OK from Vault
```

We are expecting a HTTP 204 but are receiving a 200 instead.
This is because the [Vault API](https://www.vaultproject.io/docs/auth/token.html#auth-token-revoke-token) requires a POST to the `v1/auth/token/revoke` endpoint, not a PUT.