### PR TITLE
High Availability Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 
 test:
 	./t/basic
-
+	./t/basic-ha
 push:
 	cf push vault-broker -m 128M -k 256M --no-start
 	cf set-env vault-broker VAULT_ADDR "$(VAULT_ADDR)"

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: vault-broker

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ assigns it a _binding ID_.  Let's assume that that binding ID is
    - **token** - The access token ("flibbertygibbet")
    - **vault** - The URL to the Vault (see `$VAULT_ADVERTISE_ADDR`,
      in the _Configuration_ section)
+   - **vaults** - The Vault URLs used for HA (see `$VAULT_ADVERTISE_ADDR`,
+     in the _Configuration_ section)
    - **root**  - The root path under which to create secrets.  In
      this example, that will be `secret/1234`
 4. Record the token in an accounting record, at
@@ -122,6 +124,18 @@ variables:
     `$VAULT_ADDR`, but can be set separately if you need or want
     applications to access the Vault via DNS, or over a load
     balancer.
+  - **$VAULT_ADDRS** - The addresses to use when accessing the Vault
+    to set up new policies and manage provisioned services.  This
+    variable is **required** for HA. If the first address in the list
+    is unavailable, the broker will failover to the other vaults in
+    the list for token renewel/issuing/etc. (Note: the application 
+    bound to the broker must also be configured to fail over to the 
+    other addresses in the list)
+  - **$VAULT_ADVERTISE_ADDRS** - The addresses to hand out to bound
+    applications, along with their credentials.  This defaults to
+    `$VAULT_ADDRS`, but can be set separately if you need or want
+    applications to access Vaults via DNS, or over load
+    balancers.
   - **$VAULT_TOKEN** - The token that the service broker will use
     when interacting with the Vault.  This variable is
     **required**, and you probably want to set it to a root token.

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -18,7 +18,7 @@ meta:
   pipeline: (( grab meta.name ))
 
   go:
-    version: 1.8
+    version: 1.9
     module:  (( concat "github.com/" meta.github.owner "/" meta.github.repo ))
     cmd_module: (( grab meta.go.module ))
     binary:  (( grab meta.github.repo ))

--- a/main.go
+++ b/main.go
@@ -522,6 +522,15 @@ Environment Variables:
 	os.Exit(rc)
 }
 
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 func version() {
 	v := "(development version)"
 	if Version != "" {
@@ -613,6 +622,10 @@ func main() {
 	BackendURLs = strings.Split(strings.Replace(os.Getenv("VAULT_ADDRS"), " ", "", -1), ",")
 	if os.Getenv("VAULT_ADDRS") == "" {
 		BackendURLs = []string{BackendURL}
+	}
+
+	if !stringInSlice(BackendURL, BackendURLs) {
+		BackendURLs = append([]string{BackendURL}, BackendURLs...)
 	}
 
 	BackendPublicIPs = strings.Split(strings.Replace(os.Getenv("VAULT_ADVERTISE_ADDRS"), " ", "", -1), ",")

--- a/main.go
+++ b/main.go
@@ -450,7 +450,7 @@ func (vault *VaultBroker) checkBackendHealth() {
 	for _, backend := range BackendURLs {
 		currentStatus, ok := BackendHealth.Load(backend)
 		if !ok {
-			log.Errorf("[health] Backend %s not found in health map...skipping")
+			log.Errorf("[health] Backend %s not found in health map...skipping", backend)
 		}
 		healthy := true
 		res, err := vault.HTTP.Get(fmt.Sprintf("%s%s", backend, "/v1/sys/health?standbyok=true"))

--- a/main.go
+++ b/main.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jhunt/go-log"
 	"github.com/pborman/uuid"
 	"github.com/pivotal-cf/brokerapi"
 	"github.com/pivotal-golang/lager"
-	"github.com/jhunt/go-log"
 )
 
 var (
@@ -31,19 +31,24 @@ var (
 	AuthUsername string
 	AuthPassword string
 
-	BackendURL      string
-	BackendPublic   string
-	BackendToken    string
-	BackendInsecure bool
-	BackendRefresh  int
+	BackendURL       string
+	BackendURLs      []string
+	BackendPublic    string
+	BackendPublicIPs []string
+	BackendToken     string
+	BackendInsecure  bool
+	BackendRefresh   int
+
+	BackendHealth sync.Map
 
 	Version string
 )
 
 type Credentials struct {
-	Vault string `json:"vault"`
-	Token string `json:"token"`
-	Root  string `json:"root"`
+	Vault  string   `json:"vault"`
+	Vaults []string `json:"vaults"`
+	Token  string   `json:"token"`
+	Root   string   `json:"root"`
 }
 
 func ReadSecret(in io.Reader) (map[string]string, error) {
@@ -88,20 +93,28 @@ func (vault *VaultBroker) NewRequest(method, url string, data interface{}) (*htt
 }
 
 func (vault *VaultBroker) Do(method, url string, data interface{}) (*http.Response, error) {
-	req, err := vault.NewRequest(method, fmt.Sprintf("%s%s", BackendURL, url), data)
-	if err != nil {
-		return nil, err
-	}
+	for _, backend := range BackendURLs {
+		currentStatus, ok := BackendHealth.Load(backend)
+		if !ok || currentStatus.(bool) != true {
+			continue
+		}
+		log.Infof("[request %s] using vault at %s", url, backend)
+		req, err := vault.NewRequest(method, fmt.Sprintf("%s%s", backend, url), data)
+		if err != nil {
+			return nil, err
+		}
 
-	req.Header.Add("X-Vault-Token", BackendToken)
-	res, err := vault.HTTP.Do(req)
-	if err != nil {
-		return res, fmt.Errorf("Failed to interact with Vault: %s", err)
+		req.Header.Add("X-Vault-Token", BackendToken)
+		res, err := vault.HTTP.Do(req)
+		if err != nil {
+			log.Errorf("Failed to interact with Vault at %s: %s", backend, err)
+		} else if res.StatusCode == 503 {
+			log.Errorf("Vault is sealed (HTTP 503)")
+		} else {
+			return res, nil
+		}
 	}
-	if res.StatusCode == 503 {
-		return res, fmt.Errorf("Vault is sealed (HTTP 503)")
-	}
-	return res, nil
+	return nil, fmt.Errorf("Could not contact or errored contacting all vaults. Check log for details")
 }
 
 func (vault *VaultBroker) List(path string) ([]string, error) {
@@ -354,9 +367,10 @@ func (vault *VaultBroker) Bind(instanceID, bindingID string, details brokerapi.B
 
 	log.Infof("[bind %s / %s] success", instanceID, bindingID)
 	binding.Credentials = Credentials{
-		Vault: BackendPublic,
-		Token: token,
-		Root:  fmt.Sprintf("secret/%s", instanceID),
+		Vault:  BackendPublic,
+		Vaults: BackendPublicIPs,
+		Token:  token,
+		Root:   fmt.Sprintf("secret/%s", instanceID),
 	}
 	return binding, nil
 }
@@ -420,6 +434,34 @@ func (vault *VaultBroker) Unbind(instanceID, bindingID string, details brokerapi
 func (vault *VaultBroker) Update(instanceID string, details brokerapi.UpdateDetails, asyncAllowed bool) (brokerapi.IsAsync, error) {
 	// Update instance here
 	return false, fmt.Errorf("not implemented")
+}
+
+func (vault *VaultBroker) HealthCheck() {
+	log.Infof("[health] health will be performed every 30 seconds...")
+	t := time.Tick(time.Duration(30) * time.Second)
+	vault.checkBackendHealth()
+
+	for _ = range t {
+		vault.checkBackendHealth()
+	}
+}
+
+func (vault *VaultBroker) checkBackendHealth() {
+	for _, backend := range BackendURLs {
+		currentStatus, ok := BackendHealth.Load(backend)
+		if !ok {
+			log.Errorf("[health] Backend %s not found in health map...skipping")
+		}
+		healthy := true
+		res, err := vault.HTTP.Get(fmt.Sprintf("%s%s", backend, "/v1/sys/health?standbyok=true"))
+		if err != nil || res.StatusCode != 200 {
+			healthy = false
+		}
+		if currentStatus.(bool) != healthy {
+			log.Warnf("[health] Vault at %s is now marked as healthy:%t", backend, healthy)
+			BackendHealth.Store(backend, healthy)
+		}
+	}
 }
 
 func usage(rc int) {
@@ -562,9 +604,25 @@ func main() {
 		fmt.Fprintf(os.Stderr, "No VAULT_ADDR environment variable set!\n")
 		ok = false
 	}
+
 	BackendPublic = os.Getenv("VAULT_ADVERTISE_ADDR")
 	if BackendPublic == "" {
 		BackendPublic = BackendURL
+	}
+
+	BackendURLs = strings.Split(strings.Replace(os.Getenv("VAULT_ADDRS"), " ", "", -1), ",")
+	if os.Getenv("VAULT_ADDRS") == "" {
+		BackendURLs = []string{BackendURL}
+	}
+
+	BackendPublicIPs = strings.Split(strings.Replace(os.Getenv("VAULT_ADVERTISE_ADDRS"), " ", "", -1), ",")
+	if os.Getenv("VAULT_ADVERTISE_ADDRS") == "" {
+		BackendPublicIPs = BackendURLs
+	}
+
+	// Initialize map of backend health to initially be true
+	for i := 0; i < len(BackendURLs); i++ {
+		BackendHealth.Store(BackendURLs[i], true)
 	}
 
 	BackendToken = os.Getenv("VAULT_TOKEN")
@@ -593,6 +651,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	log.Infof("BackendURL: %s - BackendURLs: %v - BackendPublic: %s - BackendPublicIPs: %v", BackendURL, BackendURLs, BackendPublic, BackendPublicIPs)
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "3000"
@@ -619,9 +679,9 @@ func main() {
 		Tokens: make(map[string]bool),
 	}
 
+	go vault.HealthCheck()
 	vault.Scan()
 	go vault.RenewTokens(BackendRefresh)
-
 	log.Infof("Vault Service Broker listening on %s", bind)
 	http.Handle("/", brokerapi.New(
 		vault,

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+  - name: vault-broker
+    buildpack: go_buildpack
+    command: vault-broker
+    env:
+      GOVERSION: go1.9
+      GOPACKAGENAME: github.com/cloudfoundry-community/vault-broker

--- a/t/basic-ha
+++ b/t/basic-ha
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+rm -rf t/tmp; mkdir -p t/tmp
+export HOME=${PWD}/t/tmp
+
+uuid() {
+	uuidgen | tr A-Z a-z
+}
+
+TESTS=0
+FAILS=0
+ok() {
+	echo "[ ok ] $@"
+	TESTS=$(( TESTS + 1 ))
+}
+fail() {
+	echo "[FAIL] $@"
+	FAILS=$(( FAILS + 1 ))
+	TESTS=$(( TESTS + 1 ))
+}
+diag() {
+	echo $*
+}
+
+VAULT_PID=
+BROKER_PID=
+
+BROKER_GUID=$(uuid)
+BROKER_SERVIER_NAME=vault
+AUTH_USERNAME=admin
+AUTH_PASSWORD=sekrit
+BROKER_PORT=8242
+BROKER_URL=http://127.0.0.1:${BROKER_PORT}
+export BROKER_GUID BROKER_SERVICE_NAME
+export AUTH_USERNAME AUTH_PASSWORD
+export PORT=${BROKER_PORT}
+
+VAULT_ADDRESS=127.0.0.1:8241
+VAULT_ADDR=http://${VAULT_ADDRESS}
+VAULT_ADDRS=http://192.168.1.1:8241,http://172.16.1.1:8241
+VAULT_ADVERTISE_ADDR=${VAULT_ADDR}
+VAULT_ADVERTISE_ADDRS=${VAULT_ADDRESS},http://foo.bar
+VAULT_TOKEN=$(uuid)
+export VAULT_TOKEN VAULT_ADDR VAULT_ADVERTISE_ADDR VAULT_ADDRS VAULT_ADVERTISE_ADDRS
+
+dump_logs() {
+	(echo "------------------------------------"
+	 for log in vault broker curl; do
+		if [[ ! -f t/tmp/${log}.log ]]; then
+			echo "!! skipping t/tmp/${log}.log (enoent...)"
+		else
+			echo "$ cat t/tmp/${log}.log"
+			cat t/tmp/${log}.log
+		fi
+		echo
+	 done
+	 echo "------------------------------------"
+	 echo) >&2
+}
+
+OK=
+atexit() {
+	set +ex
+	if [[ -z $OK ]]; then
+		dump_logs
+	fi
+
+	if [[ -n ${VAULT_PID} ]]; then
+		kill -INT ${VAULT_PID}
+	fi
+	if [[ -n ${BROKER_PID} ]]; then
+		kill -INT ${BROKER_PID}
+	fi
+}
+trap "atexit" INT QUIT TERM EXIT
+
+bail() {
+	(echo $* ; echo "aborting..." ; echo
+	 dump_logs
+	) >&2
+	exit 2
+}
+
+run_vault() {
+	vault server \
+	        -dev \
+	        -dev-root-token-id="${VAULT_TOKEN}" \
+	        -dev-listen-address="${VAULT_ADDRESS}" \
+	        > t/tmp/vault.log 2>&1 &
+	VAULT_PID=$!
+
+	sleep 1
+	rm -f ${HOME}/.saferc
+	safe target -k tests ${VAULT_ADDR}
+	echo "${VAULT_TOKEN}" | safe auth token
+	safe write secret/handshake knock=knock
+	safe check secret/handshake || bail "failed to setup vault"
+	safe tree
+}
+
+run_broker() {
+	./vault-broker > t/tmp/broker.log 2>&1 &
+	BROKER_PID=$!
+	sleep 10
+}
+
+http() {
+	method=${1?http() requires a METHOD argument} ; shift
+	url=${1?http() requires a URL argument}       ; shift
+
+	echo >>t/tmp/curl.log ":: ${method} ${BROKER_URL}${url}"
+	curl --fail -vv -u ${AUTH_USERNAME}:${AUTH_PASSWORD} -X ${method} ${BROKER_URL}${url} "$@" 2>>t/tmp/curl.log \
+		|| bail "curl ${method} ${url} FAILED"
+	echo >>t/tmp/curl.log
+}
+
+echo >&2 "starting up vault..."
+run_vault
+echo >&2 "vault is up and running..."
+
+echo >&2 "spinning up vault-broker..."
+run_broker
+echo >&2 "vault-broker is up and running..."
+
+INST_1=$(uuid)
+BIND_1_1=$(uuid)
+
+set -e
+http GET /v2/catalog | tee t/tmp/catalog.json | jq -r .
+
+http PUT /v2/service_instances/${INST_1} -d '{
+  "organization_guid" : "'$(uuid)'",
+  "space_guid"        : "'$(uuid)'",
+  "service_id"        : "'${BROKER_GUID}'",
+  "plan_id"           : "'${BROKER_GUID}'.shared"
+}' | tee t/tmp/provision.json | jq -r .
+
+http PUT /v2/service_instances/${INST_1}/service_bindings/${BIND_1_1} -d '{
+  "service_id"        : "'${BROKER_GUID}'",
+  "plan_id"           : "'${BROKER_GUID}'.shared"
+}' | tee t/tmp/bind.json | jq -r .
+got_vault=$(jq -r .credentials.vault <t/tmp/bind.json)
+got_token=$(jq -r .credentials.token <t/tmp/bind.json)
+got_root=$( jq -r .credentials.root  <t/tmp/bind.json)
+if [[ ${got_vault} != "${VAULT_ADVERTISE_ADDR}" ]]; then
+	fail "vault-broker did not use the VAULT_ADVERTISE_ADDR when giving out credentials"
+	diag "      expected '${got_vault}'"
+	diag "      to equal '${VAULT_ADVERTISE_ADDR}'"
+	diag
+else
+	ok "vault-broker gives out VAULT_ADVERTISE_ADDR instead of VAULT_ADDR"
+fi
+if [[ -z ${got_token} ]]; then
+	fail "vault-broker did not grant us a vault token when we bound the service"
+else
+	ok "vault-broker granted us a vault token when we bound the service"
+fi
+
+safe target -k inst1 ${got_vault}
+echo "${got_token}" | safe auth token
+safe write ${got_root}/test1 key=value
+if safe exists ${got_root}/test1:key; then
+	ok "able to write to the root path using the supplied token"
+else
+	fail "unable to write to the root path using the supplied token"
+fi
+
+got_secret=$(safe read ${got_root}/test1:key)
+if [[ "${got_secret}" != "value" ]]; then
+	fail "vault did not store our secret properly..."
+	diag "      expected '${got_secret}'"
+	diag "      to equal 'value'"
+else
+	ok "stored and retrieved a secret properly using generated credentials"
+fi
+
+http DELETE /v2/service_instances/${INST_1}/service_bindings/${BIND_1_1}
+if safe exists ${got_root}/test1:key; then
+	fail "vault broker did not revoke our root token after the service was unbound"
+else
+	ok "vault broker revokes root token after the service is unbound"
+fi
+
+set +e
+
+if kill -0 ${BROKER_PID} >/dev/null 2>&1; then
+	echo >&2 "shutting down vault-broker..."
+	kill -TERM ${BROKER_PID}
+	wait ${BROKER_PID}
+fi
+BROKER_PID=
+
+if kill -0 ${VAULT_PID} >/dev/null 2>&1; then
+	echo >&2 "shutting down vault..."
+	kill -INT ${VAULT_PID}
+	wait ${VAULT_PID}
+fi
+VAULT_PID=
+
+ps -ef | grep vaul[t]
+
+echo >&2 "done"
+OK=1
+echo
+if [[ $FAILS -gt 0 ]]; then
+	echo "$FAILS / $TESTS tests failed"
+	exit 1
+else
+	echo "ALL TESTS PASSED"
+	exit 0
+fi
+
+# vim:ft=bash


### PR DESCRIPTION
Implement High Availability support for the vault broker. 

IPs and Advertise URLs are provided in a similar fashion to the current implementation.
If they are set and the broker is unable to contact the vault via the first address in the list (or the VAULT_ADDR that was provided) it will failover to the next vault in the list. This allows operators to set precedence (if applicable).

Once a vault is marked as failed, future requests are diverted to alternate vaults until the health check routine finds that they are back online.